### PR TITLE
Bump opa version to 0.34.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG OPA_VERSION=0.31.0
+ARG OPA_VERSION=0.34.1
 ARG KILLGRAVE_VERSION=0.4.1
 
 ADD https://github.com/open-policy-agent/opa/releases/download/v$OPA_VERSION/opa_linux_amd64_static /bin/opa


### PR DESCRIPTION
## Why

Newer versions of opa image has performance improvements and new features that is great for us to use

## What

Bump opa version to 0.34.1